### PR TITLE
Replaces `boolean` (an alias) with `bool` for consistency

### DIFF
--- a/src/Patreon/Api/Client.php
+++ b/src/Patreon/Api/Client.php
@@ -54,8 +54,8 @@ class Client
     /**
      * Executes a GET request to the Patreon API.
      *
-     * @param string  $path           API request path
-     * @param boolean $authentication Make request to authenticated endpoint?
+     * @param string $path           API request path
+     * @param bool   $authentication Make request to authenticated endpoint?
      *
      * @return \Psr\Http\Message\ResponseInterface
      */

--- a/src/Patreon/Entities/Campaign.php
+++ b/src/Patreon/Entities/Campaign.php
@@ -38,14 +38,14 @@ class Campaign extends Entity
     /**
      * Unknown.
      *
-     * @var boolean
+     * @var bool
      */
     public $display_patron_goals;
 
     /**
      * Whether or not the campaigns earnings are visible.
      *
-     * @var boolean
+     * @var bool
      */
     public $earnings_visibility;
 
@@ -69,7 +69,7 @@ class Campaign extends Entity
      * Does the campaign charge immediately when a new pledge is created
      * instead of waiting until the next billing cycle?
      *
-     * @var boolean
+     * @var bool
      */
     public $is_charge_upfront;
 
@@ -78,7 +78,7 @@ class Campaign extends Entity
      * Maybe: a legacy version of is_charge_upfront; or is_charge_upfront is
      * the legacy field?
      *
-     * @var boolean
+     * @var bool
      */
     public $is_charged_immediately;
 
@@ -87,28 +87,28 @@ class Campaign extends Entity
      * Maybe: a legacy version of is_charge_upfront; or is_charge_upfront is
      * the legacy field?
      *
-     * @var boolean
+     * @var bool
      */
     public $is_first_month_upfront;
 
     /**
      * Does the campaign bill every month, instead of per creation?
      *
-     * @var boolean
+     * @var bool
      */
     public $is_monthly;
 
     /**
      * Does the campaign have adult content?
      *
-     * @var boolean
+     * @var bool
      */
     public $is_nsfw;
 
     /**
      * Unknown.
      *
-     * @var boolean
+     * @var bool
      */
     public $is_plural;
 

--- a/src/Patreon/Entities/Pledge.php
+++ b/src/Patreon/Entities/Pledge.php
@@ -34,7 +34,7 @@ class Pledge extends Entity
     /**
      * Does the patron have a shipping address associated with this pledge?
      *
-     * @var boolean
+     * @var bool
      */
     public $has_shipping_address;
 
@@ -43,7 +43,7 @@ class Pledge extends Entity
      * Notes: A pledge can only be paused if the campaign is per-month, a
      * per-post campaign cannot have any paused pledges.
      *
-     * @var boolean
+     * @var bool
      */
     public $is_paused;
 
@@ -51,7 +51,7 @@ class Pledge extends Entity
      * Legacy / unused.
      * Source: https://www.patreondevelopers.com/t/131/3
      *
-     * @var boolean
+     * @var bool
      */
     public $patron_pays_fees;
 

--- a/src/Patreon/Entities/Reward.php
+++ b/src/Patreon/Entities/Reward.php
@@ -82,7 +82,7 @@ class Reward extends Entity
     /**
      * Is this Reward visible on the campaign?
      *
-     * @var boolean
+     * @var bool
      */
     public $published;
 
@@ -105,7 +105,7 @@ class Reward extends Entity
     /**
      * Does the reward require a shipping address?
      *
-     * @var boolean
+     * @var bool
      */
     public $requires_shipping;
 

--- a/src/Patreon/Entities/User.php
+++ b/src/Patreon/Entities/User.php
@@ -79,7 +79,7 @@ class User extends Entity
     /**
      * Does the user have a password? False if they signed up using Facebook.
      *
-     * @var boolean
+     * @var bool
      */
     public $has_password;
 
@@ -94,28 +94,28 @@ class User extends Entity
     /**
      * Is the account deleted?
      *
-     * @var boolean
+     * @var bool
      */
     public $is_deleted;
 
     /**
      * Is the users email address verified?
      *
-     * @var boolean
+     * @var bool
      */
     public $is_emailed_verified;
 
     /**
      * Unknown.
      *
-     * @var boolean
+     * @var bool
      */
     public $is_nuked;
 
     /**
      * Unknown.
      *
-     * @var boolean
+     * @var bool
      */
     public $is_suspended;
 

--- a/src/Patreon/Patreon.php
+++ b/src/Patreon/Patreon.php
@@ -22,7 +22,7 @@ class Patreon
     /**
      * Should requests be made to the authenticated endpoint?
      *
-     * @var boolean
+     * @var bool
      */
     protected $authenticated = true;
 

--- a/src/Patreon/Resources/Resource.php
+++ b/src/Patreon/Resources/Resource.php
@@ -44,7 +44,7 @@ abstract class Resource
      * Constructs a new Resource.
      *
      * @param \Squid\Patreon\Api\Client $client        Patreon API Client
-     * @param boolean                   $authenticated Make request to authenticated?
+     * @param bool                      $authenticated Make request to authenticated?
      */
     public function __construct(Client $client, bool $authenticated = true)
     {
@@ -103,7 +103,7 @@ abstract class Resource
     /**
      * Are requests made to the authenticated endpoint for this resource?
      *
-     * @return boolean
+     * @return bool
      */
     public function isAuthenticated(): bool
     {

--- a/src/Patreon/Resources/Webhook.php
+++ b/src/Patreon/Resources/Webhook.php
@@ -38,7 +38,7 @@ class Webhook extends Resource
      *
      * @throws Exception
      *
-     * @return boolean
+     * @return bool
      */
     public function validateSignature(
         string $body,


### PR DESCRIPTION
> Aliases for the above scalar types are not supported. Instead, they
are treated as class or interface names. For example, using boolean as
a parameter or return type will require an argument or return value
that is an instanceof the class or interface boolean, rather than of
type bool.